### PR TITLE
Next preview mode

### DIFF
--- a/pages/api/exit-preview.js
+++ b/pages/api/exit-preview.js
@@ -1,0 +1,7 @@
+export default function handler(req, res) {
+  res.clearPreviewData();
+
+  res.writeHead(307, { location: '/' });
+
+  return res.end();
+}

--- a/pages/api/preview.js
+++ b/pages/api/preview.js
@@ -1,0 +1,13 @@
+export default function handler(req, res) {
+  res.setPreviewData({});
+
+  const key = 'BIRDMAN';
+
+  if (req.query.key !== key) {
+    return res.status(401).json({ message: 'Invalid Key to enable preview' });
+  }
+
+  res.writeHead(307, { location: '/' });
+
+  return res.end();
+}

--- a/pages/sobre.js
+++ b/pages/sobre.js
@@ -1,8 +1,8 @@
 import AboutScreen, { getContent } from '../src/components/screens/AboutScreen';
 import websitePageHOC from '../src/components/wrappers/WebsitePage/hoc';
 
-export async function getStaticProps() {
-  const messages = await getContent();
+export async function getStaticProps({ preview }) {
+  const messages = await getContent({ preview });
 
   return {
     props: {

--- a/src/components/foundation/Text/index.js
+++ b/src/components/foundation/Text/index.js
@@ -6,6 +6,7 @@ import styled, { css } from 'styled-components';
 import { propToStyle } from '../../../theme/utils/propToStyle';
 import { breakpointsMedia } from '../../../theme/utils/breakpointsMedia';
 import Link from '../../commons/Link';
+import { WebsitePageContext } from '../../wrappers/WebsitePage/context';
 
 export const TextStyleVariantsMap = {
   paragraph1: css`
@@ -50,25 +51,31 @@ const TextBase = styled.span`
   ${propToStyle('fontWeight')}
 `;
 
-export default function Text({ tag, variant, children, href, ...props }) {
+export default function Text({
+  tag,
+  variant,
+  children,
+  href,
+  cmsKey,
+  ...props
+}) {
+  const websitePageContext = React.useContext(WebsitePageContext);
+
+  const componentContent = cmsKey
+    ? websitePageContext.getCMSContent(cmsKey)
+    : children;
+
   if (href) {
     return (
       <TextBase href={href} as={Link} variant={variant} {...props}>
-        {children}
+        {componentContent}
       </TextBase>
     );
   }
 
   return (
-    <TextBase
-      as={tag}
-      variant={variant}
-      {...props}
-      // style
-      // className
-      // e ai vai
-    >
-      {children}
+    <TextBase as={tag} variant={variant} {...props}>
+      {componentContent}
     </TextBase>
   );
 }
@@ -78,6 +85,7 @@ Text.propTypes = {
   variant: PropTypes.string,
   children: PropTypes.node,
   href: PropTypes.string,
+  cmsKey: PropTypes.string,
 };
 
 Text.defaultProps = {
@@ -85,4 +93,5 @@ Text.defaultProps = {
   variant: 'paragraph1',
   children: null,
   href: '',
+  cmsKey: undefined,
 };

--- a/src/components/screens/AboutScreen/getContent.js
+++ b/src/components/screens/AboutScreen/getContent.js
@@ -1,6 +1,6 @@
 import CMSGraphQLClient, { gql } from '../../../infra/cms/CMSGraphQLClient';
 
-export async function getContent() {
+export async function getContent({ preview }) {
   const query = gql`
     query {
       pageSobre {
@@ -10,7 +10,7 @@ export async function getContent() {
     }
   `;
 
-  const client = CMSGraphQLClient();
+  const client = CMSGraphQLClient({ preview });
 
   const response = await client.query({ query });
 

--- a/src/components/screens/AboutScreen/index.js
+++ b/src/components/screens/AboutScreen/index.js
@@ -16,9 +16,12 @@ export default function AboutScreen({ messages }) {
             offset={{ md: 2 }}
             flex={1}
           >
-            <Text variant="title" tag="h2" color="tertiary.main">
-              {messages.pageSobre.pageTitle}
-            </Text>
+            <Text
+              variant="title"
+              tag="h2"
+              color="tertiary.main"
+              cmsKey="pageSobre.pageTitle"
+            />
 
             <Box
               dangerouslySetInnerHTML={{

--- a/src/components/wrappers/WebsitePage/context/index.js
+++ b/src/components/wrappers/WebsitePage/context/index.js
@@ -1,0 +1,6 @@
+import React from 'react';
+
+export const WebsitePageContext = React.createContext({
+  toggleModalCadastro: () => {},
+  getCMSContent: (cmsKey) => cmsKey,
+});

--- a/src/components/wrappers/WebsitePage/hoc/index.js
+++ b/src/components/wrappers/WebsitePage/hoc/index.js
@@ -11,7 +11,11 @@ export default function websitePageHOC(
 ) {
   return (props) => (
     <WebsiteGlobalProvider>
-      <WebsitePageWrapper {...pageWrapperProps} {...props.pageWrapperProps}>
+      <WebsitePageWrapper
+        {...pageWrapperProps}
+        {...props.pageWrapperProps}
+        messages={props.messages}
+      >
         <PageComponent {...props} />
       </WebsitePageWrapper>
     </WebsiteGlobalProvider>

--- a/src/components/wrappers/WebsitePage/index.js
+++ b/src/components/wrappers/WebsitePage/index.js
@@ -1,5 +1,6 @@
 /* eslint-disable react/jsx-props-no-spreading */
 import React from 'react';
+import get from 'lodash/get';
 import PropTypes from 'prop-types';
 import Footer from '../../commons/Footer';
 import Menu from '../../commons/Menu';
@@ -7,16 +8,16 @@ import Modal from '../../commons/Modal';
 import { Box } from '../../foundation/layout/Box';
 import FormCadastro from '../../patterns/FormCadastro';
 import { SEO } from '../../commons/SEO';
+import { WebsitePageContext } from './context';
 
-export const WebsitePageContext = React.createContext({
-  toggleModalCadastro: () => {},
-});
+export { WebsitePageContext } from './context';
 
 export default function WebsitePageWrapper({
   children,
   seoProps,
   pageBoxProps,
   menuProps,
+  messages,
 }) {
   const [isModalOpen, setIsModalOpen] = React.useState(false);
 
@@ -26,6 +27,7 @@ export default function WebsitePageWrapper({
         toggleModalCadastro: () => {
           setIsModalOpen(!isModalOpen);
         },
+        getCMSContent: (cmsKey) => get(messages, cmsKey),
       }}
     >
       <SEO {...seoProps} />
@@ -63,6 +65,7 @@ WebsitePageWrapper.defaultProps = {
   menuProps: {
     display: true,
   },
+  messages: {},
 };
 
 WebsitePageWrapper.propTypes = {
@@ -78,4 +81,6 @@ WebsitePageWrapper.propTypes = {
     backgroundPosition: PropTypes.string,
   }),
   children: PropTypes.node.isRequired,
+  // eslint-disable-next-line react/forbid-prop-types
+  messages: PropTypes.object,
 };

--- a/src/infra/cms/CMSGraphQLClient.js
+++ b/src/infra/cms/CMSGraphQLClient.js
@@ -2,9 +2,11 @@ import { GraphQLClient, gql as GraphQLTag } from 'graphql-request';
 
 export const gql = GraphQLTag;
 
-function CMSGraphQLClient() {
+function CMSGraphQLClient({ preview }) {
   const TOKEN = process.env.DATO_CMS_TOKEN;
-  const DatoCMSURL = 'https://graphql.datocms.com/';
+  const DatoCMSURL = preview
+    ? 'https://graphql.datocms.com/preview'
+    : 'https://graphql.datocms.com/';
 
   const client = new GraphQLClient(DatoCMSURL, {
     headers: {


### PR DESCRIPTION
- Criado configuração para habilitar o modo preview através da url /api/preview e para desabilitar /api/exit-preview
- Utilizando a variável do next de preview, setamos a url de preview do Dato caso o modo seja esse
- Ajustado o pageHOC para receber os dados do Dato e repassar para o contexto da aplicação
- Criado a função getCMSContent, para compartilhar os dados do Dato com toda nossa aplicação
